### PR TITLE
Update util.go 

### DIFF
--- a/internal/converts/util.go
+++ b/internal/converts/util.go
@@ -31,7 +31,16 @@ func setFieldValue(tag string, field reflect.Value, nValue *nebula_type.Value) e
 		field.SetFloat(nValue.GetFVal())
 	case reflect.String:
 		field.SetString(string(nValue.GetSVal()))
+	case reflect.Struct:
+	switch field.Type().String() {
+		case "time.Time":
+			ts := nValue.GetIVal()
+			field.Set(reflect.ValueOf(time.Unix(ts, 0)))
+		default:
+			//fmt.Printf("debug: type[%v] mapping not implement\n", field.Type().String())
+		}
 	default:
+		//fmt.Printf("debug: type[%v] mapping not implement\n", field.Type().String())
 		return nil
 	}
 	return nil


### PR DESCRIPTION
ExecuteAndParse 方法，可以将 nebula 查询结果解析到struct 结构中。但 struct 中仅支持标量类型(string,number,bool等，不支持结构类型)。但time.Time 太常用了，本提交增加了对 time.Time 类型字段的支持。